### PR TITLE
make sure we build a 64 bits enabled platform on Darwin

### DIFF
--- a/kerl
+++ b/kerl
@@ -301,6 +301,10 @@ do_build()
                     fi
                 fi
             fi
+            ISA64=`(sysctl -n hw.optional.x86_64) 2>/dev/null`
+            if [ "$ISA64" = "1" ]; then
+                KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --enable-darwin-64bit"
+            fi
         ;;
         *)
         ;;


### PR DESCRIPTION
This patch detect if 64 bits is supported and build erlang accordingly.