### PR TITLE
Do not clear ENV config vars

### DIFF
--- a/kerl
+++ b/kerl
@@ -23,11 +23,13 @@
 
 ERLANG_DOWNLOAD_URL=http://www.erlang.org/download
 
-KERL_BASE_DIR="$HOME/.kerl"
-KERL_CONFIG="$HOME/.kerlrc"
-KERL_DOWNLOAD_DIR="$KERL_BASE_DIR/archives"
-KERL_BUILD_DIR="$KERL_BASE_DIR/builds"
-KERL_GIT_DIR="$KERL_BASE_DIR/gits"
+# Default values
+: ${KERL_BASE_DIR:="$HOME/.kerl"}
+: ${KERL_CONFIG:="$HOME/.kerlrc"}
+: ${KERL_DOWNLOAD_DIR:="$KERL_BASE_DIR/archives"}
+: ${KERL_BUILD_DIR:="$KERL_BASE_DIR/builds"}
+: ${KERL_GIT_DIR:="$KERL_BASE_DIR/gits"}
+
 if [ -n "$KERL_CONFIGURE_OPTIONS" ]; then
     _KCO="$KERL_CONFIGURE_OPTIONS"
 fi
@@ -43,10 +45,6 @@ fi
 if [ -n "$KERL_DEPLOY_RSYNC_OPTIONS" ]; then
     _KDRSYNC="$KERL_DEPLOY_RSYNC_OPTIONS"
 fi
-KERL_CONFIGURE_OPTIONS=
-KERL_CONFIGURE_APPLICATIONS=
-KERL_SASL_STARTUP=
-KERL_INSTALL_MANPAGES=
 
 # ensure the base dir exsists
 mkdir -p "$KERL_BASE_DIR"


### PR DESCRIPTION
According to the docs it is possible to configure kerl both by using `.kerlrc`
and passing ENV variables from the command-line, i.e.

    KERL_INSTALL_MANPAGES=yes ./kerl install <build> <path>

However the ENV vars were being cleared/overriden, so you could only use `.kerlrc`.

This fixes it.