### PR TITLE
Commit ddf335 added the ability to support erlang's new release naming c...

### DIFF
--- a/kerl
+++ b/kerl
@@ -129,7 +129,7 @@ get_releases()
     curl -L -s $ERLANG_DOWNLOAD_URL/ | \
         sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
                      -e '/^R1|^[0-9]/!d' | \
-        sed -e "s/\([^:]*\)/\1:\1/" | sort | cut -d':' -f2
+        sed -e "s/\(^R\?\([^:]*\)\)/\2:\1/" | sort | cut -d':' -f2
 }
 
 update_checksum_file()

--- a/kerl
+++ b/kerl
@@ -129,7 +129,6 @@ get_releases()
     curl -L -s $ERLANG_DOWNLOAD_URL/ | \
         sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
                      -e '/^R1|^[0-9]/!d' | \
-        sed -e "s/^R\(.*\)/\1:R\1/" | \
         sed -e "s/\([^:]*\)/\1:\1/" | sort | cut -d':' -f2
 }
 


### PR DESCRIPTION
...onvention; but it also broke support for releases that begin with 'R'.  Removing this sed command fixes.

I'm not a sed master; but it looks like that command removes the R from the releases. .kerl/otp_releases file goes from looking like this

R10B-0
R10B-10
R10B-1a
...
17.0
17.0-rc1
17.0-rc2

To looking like this

10B-0
10B-10
10B-1a
...
17.0
17.0-rc1
17.0-rc2

kerl now wants you to do
> kerl build 10B-0 10b-0
...
> cat /home/burrows/.kerl/archives/otp_src_10B-0.tar.gz
<HTML>
       <HEAD>
           <TITLE>Object Not Found</TITLE>
      </HEAD>
      <BODY>
      <H1>Object Not Found</H1>
The requested URL &#47;download&#47;otp_src_10B-0.tar.gz was not found on this server.
</BODY>
      </HTML>

And if you do
> kerl build R10B-0 10b-0
R10B-0 is not a valid Erlang/OTP release

So I think the leading R must remain.