### PR TITLE
Add submodule recursive init/update after branch checkout in git build

### DIFF
--- a/kerl
+++ b/kerl
@@ -283,6 +283,12 @@ do_git_build()
         rm -Rf "$KERL_BUILD_DIR/$3"
         exit 1
     fi
+    git submodule update --init --recursive > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Couldn't update submodules"
+        rm -Rf "$KERL_BUILD_DIR/$3"
+        exit 1
+    fi
     if [ ! -x otp_build ]; then
         echo "Not a valid Erlang/OTP repository"
         rm -Rf "$KERL_BUILD_DIR/$3"


### PR DESCRIPTION
SD-erlang OTP fork (https://github.com/release-project/otp) uses a submodule to bring in `percept2` application. This causes the build to fail.

This PR adds a (possibly naive) `git submodule update --init --recursive` **after** checking out the required branch