### PR TITLE
Fix Darwin LLVM detection

### DIFF
--- a/kerl
+++ b/kerl
@@ -332,7 +332,7 @@ do_build()
 {
     case "$KERL_SYSTEM" in
         Darwin)
-            if [ `gcc --version | grep -i llvm | wc -l` = "1" ]; then
+            if [ `gcc --version 2>/dev/null | grep -i llvm | wc -l` = "1" ]; then
                 if lion_support $1; then
                     KERL_CONFIGURE_OPTIONS="CFLAGS=-O0 $KERL_CONFIGURE_OPTIONS"
                 else

--- a/kerl
+++ b/kerl
@@ -456,7 +456,7 @@ kerl_deactivate()
     fi
     if [ -n "\$_KERL_ACTIVE_DIR" ]; then
         unset _KERL_ACTIVE_DIR
-    fi 
+    fi
     if [ -n "\$_KERL_SAVED_PS1" ]; then
         PS1="\$_KERL_SAVED_PS1"
         export PS1

--- a/kerl
+++ b/kerl
@@ -332,7 +332,7 @@ do_build()
 {
     case "$KERL_SYSTEM" in
         Darwin)
-            if [ `gcc --version | grep llvm | wc -l` = "1" ]; then
+            if [ `gcc --version | grep -i llvm | wc -l` = "1" ]; then
                 if lion_support $1; then
                     KERL_CONFIGURE_OPTIONS="CFLAGS=-O0 $KERL_CONFIGURE_OPTIONS"
                 else


### PR DESCRIPTION
LLVM is now specified with CAPS. We should search in a non-case sensitive way (`grep -i`).

Also prevent printing to STDERR when checking the version.