### PR TITLE
pcre grep errors fix in mac os

### DIFF
--- a/kerl
+++ b/kerl
@@ -21,6 +21,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+#Grep fix for mac pcre errors
+GREP_OPTIONS=''
+
 ERLANG_DOWNLOAD_URL=http://www.erlang.org/download
 
 KERL_BASE_DIR="$HOME/.kerl"


### PR DESCRIPTION
pcre grep errors fix in mac os.
see here:
http://erlang.org/pipermail/erlang-questions/2014-April/078526.html