### PR TITLE
Adapt to new erlang.org markup

### DIFF
--- a/kerl
+++ b/kerl
@@ -127,7 +127,7 @@ if [ $# -eq 0 ]; then usage; fi
 get_releases()
 {
     curl -L -s $ERLANG_DOWNLOAD_URL/ | \
-        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
+        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
                      -e '/^R1|^[0-9]/!d' | \
         sed -e "s/^R\(.*\)/\1:R\1/" | sed -e "s/^\([^\:]*\)$/\1-z:\1/" | sort | cut -d':' -f2
 }


### PR DESCRIPTION
I was not getting releases list, then I noticed erlang.org changed its markup so kerl regexp did not match. This gets releases list.