### PR TITLE
Auto add OpenSSL path on El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ kerl
 
 Easy building and installing of [Erlang/OTP](http://www.erlang.org) instances
 
-Kerl aims to be shell agnostic and its only dependencies, excluding what's required to actually build Erlang/OTP, are curl and git.
+Kerl aims to be shell agnostic and its only dependencies, excluding what's required to actually build Erlang/OTP, are `curl` and `git`.
 
 All is done so that, once a specific release has been built, creating a new installation is as fast as possible.
 
@@ -64,7 +64,7 @@ Note that named builds allow you to have different builds for the same Erlang/OT
     Building Erlang/OTP R14B02 (r14b02_hipe), please wait...
     Erlang/OTP R14B02 (r14b02_hipe) has been successfully built
 
-(Note that kerl uses the otp_build script internally, and './otp_build configure' disables HiPE on linux)
+(Note that kerl uses the otp_build script internally, and `./otp_build configure` disables HiPE on linux)
 
 You can verify your build has been registered:
 
@@ -90,14 +90,15 @@ And at last activate it:
 
     $ . /path/to/install/dir/activate
 
-Activation will backup your $PATH, prepend it with the installation's bin/ directory. Thus it's only valid for the current shell session, and until you activate another installation or call kerl_deactivate.
+Activation will backup your $PATH, prepend it with the installation's bin/ directory. Thus it's only valid for the current shell session, and until you activate another installation or call `kerl_deactivate`.
 
 You're now ready to work with your r14b02 installation:
 
     $ erl -version
     Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 5.8.3
 
-When you're done just type:
+When you're done just call the shell function:
+
     $ kerl_deactivate
 
 Anytime you can check which installation, if any, is currently active with:
@@ -123,21 +124,19 @@ You can delete builds and installations with the following commands:
 
     $ kerl delete build r14b02
     The r14b02 build has been deleted
-
     $ kerl delete installation /path/to/install/dir
     The installation in /path/to/install/dir has been deleted
 
-You can easily deploy an installation to another host having ssh and rsync access with the following command:
+You can easily deploy an installation to another host having `ssh` and `rsync` access with the following command:
 
     $ kerl deploy anotherhost /path/to/install/dir
-
     Cloning Erlang/OTP r14b02 (/path/to/install/dir) to anotherhost (/path/to/install/dir) ...
     On anotherhost, you can activate this installation running the following command:
     . /path/to/install/dir/activate
     Later on, you can leave the installation typing:
     kerl_deactivate
 
-As an experimental feature, you can build Erlang directly from a git repository with a command of the form "kerl build git <git_url> <git_version> <build_name>" where <git_version> can be either a branch, a tag or a commit id as it will be passed to "git checkout":
+As an experimental feature, you can build Erlang directly from a git repository with a command of the form `kerl build git <git_url> <git_version> <build_name>` where <git_version> can be either a branch, a tag or a commit id as it will be passed to `git checkout`:
 
     $ kerl build git https://github.com/erlang/otp.git dev r14b02_dev
     Checking Erlang/OTP git repositoy from https://github.com/erlang/otp.git...
@@ -151,24 +150,24 @@ You can tune kerl using the .kerlrc file in your $HOME directory.
 
 You can set the following variables:
 
-- KERL_DOWNLOAD_DIR where to put downloaded files, defaults to $HOME/.kerl/archives
-- KERL_BUILD_DIR where to hold the builds, defaults to $HOME/.kerl/builds
-- KERL_DEFAULT_INSTALL_DIR if set in ~/.kerlrc, install builds to this dir if no path is provided on installs, (recommend "$KERL_BASE_DIR/installs")
-- KERL_CONFIGURE_OPTIONS options to pass to Erlang's ./configure script, e.g. --without-termcap
-- KERL_CONFIGURE_APPLICATIONS if non-empty, subset of applications used in the builds (and subsequent installations) process, e.g. "kernel stdlib sasl"
-- KERL_CONFIGURE_DISABLE_APPLICATIONS if non-empty, subset of applications disabled in the builds (and subsequent installations) process, e.g. "odbc"
-- KERL_SASL_STARTUP use SASL system startup instead of minimal
-- KERL_USE_AUTOCONF use autoconf in the builds process
-- KERL_INSTALL_MANPAGES if non-empty will install manpages
-- KERL_INSTALL_HTMLDOCS if non-empty will install HTML docs
-- KERL_DEPLOY_SSH_OPTIONS if additional options are required, e.g. "-qx -o PasswordAuthentication=no"
-- KERL_DEPLOY_RSYNC_OPTIONS if additional options are required, e.g. "--delete"
-- KERL_ENABLE_PROMPT if set, the prompt will be prefixed with the name of the active build 
+- `KERL_DOWNLOAD_DIR` where to put downloaded files, defaults to $HOME/.kerl/archives
+- `KERL_BUILD_DIR` where to hold the builds, defaults to $HOME/.kerl/builds
+- `KERL_DEFAULT_INSTALL_DIR` if set in ~/.kerlrc, install builds to this dir if no path is provided on installs, (recommend `$KERL_BASE_DIR/installs`)
+- `KERL_CONFIGURE_OPTIONS` options to pass to Erlang's `./configure` script, e.g. `--without-termcap`
+- `KERL_CONFIGURE_APPLICATIONS` if non-empty, subset of applications used in the builds (and subsequent installations) process, e.g. `kernel stdlib sasl`
+- `KERL_CONFIGURE_DISABLE_APPLICATIONS` if non-empty, subset of applications disabled in the builds (and subsequent installations) process, e.g. `odbc`
+- `KERL_SASL_STARTUP` use SASL system startup instead of minimal
+- `KERL_USE_AUTOCONF` use autoconf in the builds process
+- `KERL_INSTALL_MANPAGES` if non-empty will install manpages
+- `KERL_INSTALL_HTMLDOCS` if non-empty will install HTML docs
+- `KERL_DEPLOY_SSH_OPTIONS` if additional options are required, e.g. `-qx -o PasswordAuthentication=no`
+- `KERL_DEPLOY_RSYNC_OPTIONS` if additional options are required, e.g. `--delete`
+- `KERL_ENABLE_PROMPT` if set, the prompt will be prefixed with the name of the active build 
 
 Note on .kerlrc
 ===============
 
-Since .kerlrc is a dot file for /bin/sh, running shell commands inside the .kerlrc will affect the shell and environment variables for the commands being executed later. For example, the shell `export` commands in .kerlrc will affect *your login shell environment* when activating curl.  Use with care.
+Since .kerlrc is a dot file for `/bin/sh`, running shell commands inside the .kerlrc will affect the shell and environment variables for the commands being executed later. For example, the shell `export` commands in .kerlrc will affect *your login shell environment* when activating `curl`.  Use with care.
 
 Glossary
 ========
@@ -187,47 +186,43 @@ Commands reference
 build
 -----
 
-Create a named build either from an official Erlang/OTP release or from a git repository
-
-### Syntax
-
     kerl build <release_code> <build_name>
     kerl build git <git_url> <git_version> <build_name>
 
-### Examples
+Creates a named build either from an official Erlang/OTP release or from a git repository.
 
     $ kerl build R14B02 r14b02
     $ kerl build git https://github.com/erlang/otp dev r14b02_dev
 
-### Tuning
+#### Tuning
 
-#### Configure options
+##### Configure options
 
-You can specify the configure options to use when building Erlang/OTP with the KERL_CONFIGURE_OPTIONS variable, either in your $HOME/.kerlrc file or prepending it to the command line.
+You can specify the configure options to use when building Erlang/OTP with the `KERL_CONFIGURE_OPTIONS` variable, either in your $HOME/.kerlrc file or prepending it to the command line.
 
     $ KERL_CONFIGURE_OPTIONS=--enable-hipe kerl build R14B02 r14b02_hipe
 
-#### Configure applications
+##### Configure applications
 
-If non-empty, you can specify the subset of applications to use when building (and subsequent installing) Erlang/OTP with the KERL_CONFIGURE_APPLICATIONS variable, either in your $HOME/.kerlrc file or prepending it to the command line.
+If non-empty, you can specify the subset of applications to use when building (and subsequent installing) Erlang/OTP with the `KERL_CONFIGURE_APPLICATIONS` variable, either in your $HOME/.kerlrc file or prepending it to the command line.
 
     $ KERL_CONFIGURE_APPLICATIONS="kernel stdlib sasl" kerl build R15B01 r15b01_minimal
 
-#### Configure disable applications
+##### Configure disable applications
 
-If non-empty, you can specify the subset of applications to disable when building (and subsequent installing) Erlang/OTP with the KERL_CONFIGURE_DISABLE_APPLICATIONS variable, either in your $HOME/.kerlrc file or prepending it to the command line.
+If non-empty, you can specify the subset of applications to disable when building (and subsequent installing) Erlang/OTP with the `KERL_CONFIGURE_DISABLE_APPLICATIONS` variable, either in your $HOME/.kerlrc file or prepending it to the command line.
 
     $ KERL_CONFIGURE_DISABLE_APPLICATIONS="odbc" kerl build R16B02 r16b02_no_odbc
 
-#### Enable autoconf
+##### Enable autoconf
 
-You can enable the use of autoconf in the build process setting KERL_USE_AUTOCONF=yes in your $HOME/.kerlrc file
+You can enable the use of `autoconf` in the build process setting `KERL_USE_AUTOCONF=yes` in your $HOME/.kerlrc file
 
-*Note*: autoconf is always enabled for git builds
+*Note*: `autoconf` is always enabled for git builds
 
-#### Using shell export command in .kerlrc
+##### Using shell export command in .kerlrc
 
-Configure variables which includes spaces such as those in CFLAGS cannot be passed on with KERL_CONFIGURE_OPTIONS. In such a case you can use shell `export` command to define the environment variables for Configure. Note well: this method has a side effect to change your shell execution environment after activating a kerl installation of Erlang/OTP. Here is an example of .kerlrc for building Erlang/OTP for FreeBSD with clang compiler:
+Configure variables which includes spaces such as those in `CFLAGS` cannot be passed on with `KERL_CONFIGURE_OPTIONS`. In such a case you can use shell `export` command to define the environment variables for `./configure`. Note well: this method has a side effect to change your shell execution environment after activating a kerl installation of Erlang/OTP. Here is an example of .kerlrc for building Erlang/OTP for FreeBSD with clang compiler:
 
     # for clang
     export CC=clang CXX=clang CFLAGS="-g -O3 -fstack-protector" LDFLAGS="-fstack-protector"
@@ -237,108 +232,97 @@ Configure variables which includes spaces such as those in CFLAGS cannot be pass
 install
 -------
 
-Install a named build to the specified filesystem location
-
-### Syntax
-
     kerl install <build_name> [path]
 
-If path is omitted the current working directory will be used. However, if KERL_DEFAULT_INSTALL_DIR is defined in ~/.kerlrc, KERL_DEFAULT_INSTALL_DIR/<build-name> will be used instead.
-
-*Note*: kerl assumes the specified directory is for its sole use. If you later delete it with the kerl delete command, the whole directory will be deleted, along with anything you may have added to it!
-
-### Example
+Installs a named build to the specified filesystem location.
 
     $ kerl install r14b02 /srv/otp/r14b02
 
-### Tuning
+If path is omitted the current working directory will be used. However, if `KERL_DEFAULT_INSTALL_DIR` is defined in ~/.kerlrc, `KERL_DEFAULT_INSTALL_DIR/<build-name>` will be used instead.
 
-#### SASL startup
+*Note*: kerl assumes the specified directory is for its sole use. If you later delete it with the kerl delete command, the whole directory will be deleted, along with anything you may have added to it!
 
-You can have SASL started automatically setting KERL_SASL_STARTUP=yes in your $HOME/.kerlrc file or prepending it to the command line
+#### Tuning
 
-#### Manpages installation
+##### SASL startup
 
-You can have manpages installed automatically setting KERL_INSTALL_MANPAGES=yes in your $HOME/.kerlrc file or prepending it to the command line
+You can have SASL started automatically setting `KERL_SASL_STARTUP=yes` in your $HOME/.kerlrc file or prepending it to the command line.
+
+##### Manpages installation
+
+You can have manpages installed automatically setting `KERL_INSTALL_MANPAGES=yes` in your $HOME/.kerlrc file or prepending it to the command line.
 
 *Note*: for git-based builds, kerl downloads and installs the newest official manpages which may or may not correspond to the contents of your local build.
 
-#### HTML docs installation
+##### HTML docs installation
 
-You can have HTML docs installed automatically setting KERL_INSTALL_HTMLDOCS=yes in your $HOME/.kerlrc file or prepending it to the command line
+You can have HTML docs installed automatically setting `KERL_INSTALL_HTMLDOCS=yes` in your $HOME/.kerlrc file or prepending it to the command line.
 
 *Note*: for git-based builds, kerl downloads and installs the newest official HTML docs which may or may not correspond to the contents of your local build.
 
 deploy
 ------
 
-Deploy the specified installation to the given host and location
-
-### Syntax
-
     kerl deploy <[user@]host> [directory] [remote_directory]
+
+Deploys the specified installation to the given host and location.
+
+    $ kerl deploy anotherhost /path/to/install/dir
 
 If remote_directory is omitted the specified directory will be used.
 
 If directory and remote_directory is omitted the current working directory will be used.
 
-*NOTE*: kerl assumes the specified host is accessible via ssh and rsync.
+*NOTE*: kerl assumes the specified host is accessible via `ssh` and `rsync`.
 
-### Example
+#### Tuning
 
-    $ kerl deploy anotherhost /path/to/install/dir
+##### Additional SSH options
 
-### Tuning
+You can have additional options given to `ssh` by setting them in the `KERL_DEPLOY_SSH_OPTIONS` variable in your $HOME/.kerlrc file or on the command line, e.g. `KERL_DEPLOY_SSH_OPTIONS='-qx -o PasswordAuthentication=no'`.
 
-#### Additional SSH options
+##### Additional RSYNC options
 
-You can have additional options given to SSH by setting them in the KERL_DEPLOY_SSH_OPTIONS variable in your $HOME/.kerlrc file or on the command line, e.g. KERL_DEPLOY_SSH_OPTIONS="-qx -o PasswordAuthentication=no"
-
-#### Additional RSYNC options
-
-You can have additional options given to RSYNC by setting them in the KERL_DEPLOY_RSYNC_OPTIONS variable in your $HOME/.kerlrc file or on the command line, e.g. KERL_DEPLOY_RSYNC_OPTIONS="--delete"
+You can have additional options given to `rsync` by setting them in the `KERL_DEPLOY_RSYNC_OPTIONS` variable in your $HOME/.kerlrc file or on the command line, e.g. `KERL_DEPLOY_RSYNC_OPTIONS='--delete'`.
 
 update
 ------
 
-Update the list of releases
-
-### Syntax
-
     kerl update releases
+
+Fetches the up-to-date list of OTP releases from erlang.org.
 
 list
 ----
 
-List the releases, builds or installations available
-
-### Syntax
-
     kerl list <releases|builds|installations>
+
+Lists the releases, builds or installations available.
 
 delete
 ------
 
-Delete the specified build or installation
-
-### Syntax
-
     kerl delete build <build_name>
     kerl delete installation <path>
 
-### Examples
+Deletes the specified build or installation.
 
-    $ kerl delete build r14b02
-    The r14b02 build has been deleted
-    $ kerl delete installation /srv/otp/r14b02
-    The installation in /srv/otp/r14b02 has been deleted
+```
+$ kerl delete build r14b02
+The r14b02 build has been deleted
+```
+
+```
+$ kerl delete installation /srv/otp/r14b02
+The installation in /srv/otp/r14b02 has been deleted
+```
 
 active
 ------
 
-Print the path of the currently active installation, if any
+    kerl active
 
-### Example
+Prints the path of the currently active installation, if any.
 
     $ kerl active
     The current active installation is:
@@ -347,9 +331,9 @@ Print the path of the currently active installation, if any
 status
 ------
 
-Print the available builds and installations as well as the currently active installation
+    kerl status
 
-### Example
+Prints the available builds and installations as well as the currently active installation.
 
     $ kerl status
     Available builds:
@@ -361,4 +345,3 @@ Print the available builds and installations as well as the currently active ins
     r14b02 /srv/otp/r14b02_dev
     ----------
     No Erlang/OTP kerl installation is currently active
-

--- a/bash_completion/kerl
+++ b/bash_completion/kerl
@@ -1,3 +1,4 @@
+#!/bin/bash
 # bash_completion for kerl
 
 _kerl()
@@ -14,33 +15,33 @@ _kerl()
             ;;
         build)
             if [ "$COMP_CWORD" -eq 2 ]; then
-                if [ -f "$HOME/.kerl/otp_releases" ]; then
-                    RELEASES=`cat "$HOME/.kerl/otp_releases"`
+                if [ -f "$HOME"/.kerl/otp_releases ]; then
+                    RELEASES=$(cat "$HOME"/.kerl/otp_releases)
                 fi
                 COMPREPLY=( $( compgen -W "git $RELEASES" -- "$cur") )
             else
-                if [ -f "$HOME/.kerl/otp_builds" ]; then
-                    BUILDS=`cat "$HOME/.kerl/otp_builds" | cut -d "," -f 2`
+                if [ -f "$HOME"/.kerl/otp_builds ]; then
+                    BUILDS=$(cut -d ',' -f 2 "$HOME"/.kerl/otp_builds)
                 fi
                 COMPREPLY=( $( compgen -W "$BUILDS" -- "$cur") )
             fi
             ;;
         installation)
-            if [ -f "$HOME/.kerl/otp_installations" ]; then
-                PATHS=`cat "$HOME/.kerl/otp_installations" | cut -d " " -f 2`
+            if [ -f "$HOME"/.kerl/otp_installations ]; then
+                PATHS=$(cut -d ' ' -f 2 "$HOME"/.kerl/otp_installations)
             fi
             COMPREPLY=( $( compgen -W "$PATHS" -- "$cur") )
             ;;
         install)
-            if [ -f "$HOME/.kerl/otp_builds" ]; then
-                BUILDS=`cat "$HOME/.kerl/otp_builds" | cut -d "," -f 2`
+            if [ -f "$HOME"/.kerl/otp_builds ]; then
+                BUILDS=$(cut -d ',' -f 2 "$HOME"/.kerl/otp_builds)
             fi
             COMPREPLY=( $( compgen -W "$BUILDS" -- "$cur") )
             ;;
          deploy)
             if [ "$COMP_CWORD" -eq 3 ]; then
-                if [ -f "$HOME/.kerl/otp_installations" ]; then
-                    PATHS=`cat "$HOME/.kerl/otp_installations" | cut -d " " -f 2`
+                if [ -f "$HOME"/.kerl/otp_installations ]; then
+                    PATHS=$(cut -d ' ' -f 2 "$HOME"/.kerl/otp_installations)
                 fi
             fi
             COMPREPLY=( $( compgen -W "$PATHS" -- "$cur") )
@@ -53,8 +54,8 @@ _kerl()
             ;;
         *)
             if [ "$COMP_CWORD" -eq 3 ]; then
-                if [ -f "$HOME/.kerl/otp_builds" ]; then
-                    BUILDS=`cat "$HOME/.kerl/otp_builds" | cut -d "," -f 2`
+                if [ -f "$HOME"/.kerl/otp_builds ]; then
+                    BUILDS=$(cut -d ',' -f 2 "$HOME"/.kerl/otp_builds)
                 fi
                 if [ -n "$BUILDS" ]; then
                     for b in $BUILDS; do
@@ -69,4 +70,3 @@ _kerl()
     esac
 }
 complete -F _kerl kerl
-

--- a/kerl
+++ b/kerl
@@ -348,7 +348,17 @@ do_build()
             RELVERSION=`uname -r`
             case "$RELVERSION" in
                 15*)
-                    KERL_CONFIGURE_OPTIONS="--with-ssl=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr $KERL_CONFIGURE_OPTIONS"
+                    echo -n $KERL_CONFIGURE_OPTIONS | grep "ssl" 1>/dev/null 2>&1
+                    # Reminder to self: 0 from grep means the string was detected
+                    if [ $? -ne 0 ]; then
+                        if [ ! -d /usr/include/openssl -o ! -d /usr/local/include/openssl ]; then
+                            if [ -d /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr ]; then
+                                KERL_CONFIGURE_OPTIONS="--with-ssl=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr $KERL_CONFIGURE_OPTIONS"
+                            else
+                                echo "WARNING: No OpenSSL library was found in the usual places. Your Erlang will be built without crypto support!"
+                            fi
+                        fi
+                    fi
                 ;;
                 *)
                 ;;

--- a/kerl
+++ b/kerl
@@ -52,11 +52,15 @@ fi
 if [ -n "$KERL_INSTALL_MANPAGES" ]; then
     _KIM="$KERL_INSTALL_MANPAGES"
 fi
+if [ -n "$KERL_BUILD_PLT" ]; then
+    _KBPLT="$KERL_BUILD_PLT"
+fi
 KERL_CONFIGURE_OPTIONS=
 KERL_CONFIGURE_APPLICATIONS=
 KERL_CONFIGURE_DISABLE_APPLICATIONS=
 KERL_SASL_STARTUP=
 KERL_INSTALL_MANPAGES=
+KERL_BUILD_PLT=
 
 # ensure the base dir exsists
 mkdir -p "$KERL_BASE_DIR" || exit 1
@@ -84,6 +88,9 @@ if [ -n "$_KDRSYNC" ]; then
 fi
 if [ -n "$_KIM" ]; then
     KERL_INSTALL_MANPAGES="$_KIM"
+fi
+if [ -n "$_KBPLT" ]; then
+    KERL_BUILD_PLT="$_KBPLT"
 fi
 
 if [ -z "$KERL_SASL_STARTUP" ]; then
@@ -119,6 +126,7 @@ usage()
     echo "  list     List releases, builds and installations"
     echo "  delete   Delete builds and installations"
     echo "  active   Print the path of the active installation"
+    echo "  plt      Print Dialyzer PLT path for the active installation"
     echo "  status   Print available builds and installations"
     echo "  prompt   Print a string suitable for insertion in prompt"
     echo "  cleanup  Remove compilation artifacts (use after installation)"
@@ -500,19 +508,12 @@ ACTIVATE
     if [ "$rel" != "git" ]; then
         if [ -n "$KERL_INSTALL_MANPAGES" ]; then
             echo "Fetching and installing manpages..."
-            FILENAME=otp_doc_man_$rel.tar.gz
-            download "$FILENAME"
-            echo "Extracting manpages"
-            cd "$absdir" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME"
+            do_install_manpages "$rel"
         fi
 
         if [ -n "$KERL_INSTALL_HTMLDOCS" ]; then
             echo "Fetching and installing HTML docs..."
-            FILENAME="otp_doc_html_$rel.tar.gz"
-            download "$FILENAME"
-            echo "Extracting HTML docs"
-            (cd "$absdir" && mkdir -p html && \
-                tar -C "$absdir/html" -xzf "$KERL_DOWNLOAD_DIR/$FILENAME")
+            do_install_htmldocs "$rel"
         fi
     else
         rel=$(get_newest_valid_release)
@@ -523,26 +524,79 @@ ACTIVATE
 
         if [ -n "$KERL_INSTALL_MANPAGES" ]; then
             echo "CAUTION: Fetching and installing newest ($rel) manpages..."
-            FILENAME=otp_doc_man_$rel.tar.gz
-            download "$FILENAME"
-            echo "Extracting manpages"
-            cd "$absdir" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME"
+            do_install_manpages "$rel"
         fi
 
         if [ -n "$KERL_INSTALL_HTMLDOCS" ]; then
-            echo "CATION: Fetching and installing newest ($rel) HTML docs..."
-            FILENAME="otp_doc_html_$rel.tar.gz"
-            download "$FILENAME"
-            echo "Extracting HTML docs"
-            (cd "$absdir" && mkdir -p html && \
-                tar -C "$absdir/html" -xzf "$KERL_DOWNLOAD_DIR/$FILENAME")
+            echo "CAUTION: Fetching and installing newest ($rel) HTML docs..."
+            do_install_htmldocs "$rel"
         fi
+    fi
+
+    if [ -n "$KERL_BUILD_PLT" ]; then
+        echo "Building Dialyzer PLT..."
+        build_plt "$absdir"
     fi
 
     echo "You can activate this installation running the following command:"
     echo ". $absdir/activate"
     echo "Later on, you can leave the installation typing:"
     echo "kerl_deactivate"
+}
+
+do_install_manpages()
+{
+    FILENAME=otp_doc_man_$1.tar.gz
+    download "$FILENAME"
+    echo "Extracting manpages"
+    cd "$absdir" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME"
+}
+
+do_install_htmldocs()
+{
+    FILENAME="otp_doc_html_$1.tar.gz"
+    download "$FILENAME"
+    echo "Extracting HTML docs"
+    (cd "$absdir" && mkdir -p html && \
+        tar -C "$absdir/html" -xzf "$KERL_DOWNLOAD_DIR/$FILENAME")
+}
+
+build_plt()
+{
+    dialyzerd=$1/dialyzer
+    mkdir -p $dialyzerd
+    plt=$dialyzerd/plt
+    build_log=$dialyzerd/build.log
+    dialyzer=$1/bin/dialyzer
+    apps=`ls -1 $1/lib | cut -d- -f1 | grep -Ev 'erl_interface|jinterface' | xargs echo`
+    $dialyzer --output_plt $plt --build_plt --apps $apps > $build_log 2>&1
+    status=$?
+    if [ $status -eq 0 -o $status -eq 2 ]; then
+        echo "Done building $plt"
+        return 0
+    else
+        echo "Error building PLT, see $build_log for details"
+        return 1
+    fi
+}
+
+do_plt()
+{
+    ACTIVE_PATH=`get_active_path`
+    if [ -n "$ACTIVE_PATH" ]; then
+        plt=$ACTIVE_PATH/dialyzer/plt
+        if [ -f "$plt" ]; then
+            echo "Dialyzer PLT for the active installation is:"
+            echo $plt
+            return 0
+        else
+            echo "There's no Dialyzer PLT for the active installation"
+            return 1
+        fi
+    else
+        echo "No Erlang/OTP kerl installation is currently active"
+        return 2
+    fi
 }
 
 do_deploy()
@@ -842,6 +896,11 @@ case "$1" in
             exit 1;
         fi
         ;;
+    plt)
+        if ! do_plt; then
+            exit 1;
+        fi
+        ;;
     status)
         echo "Available builds:"
         list_print builds
@@ -849,7 +908,9 @@ case "$1" in
         echo "Available installations:"
         list_print installations
         echo "----------"
-        do_active
+        if do_active; then
+            do_plt
+        fi
         exit 0
         ;;
     prompt)

--- a/kerl
+++ b/kerl
@@ -23,11 +23,11 @@
 
 ERLANG_DOWNLOAD_URL=http://www.erlang.org/download
 
-KERL_BASE_DIR="$HOME/.kerl"
-KERL_CONFIG="$HOME/.kerlrc"
-KERL_DOWNLOAD_DIR="$KERL_BASE_DIR/archives"
-KERL_BUILD_DIR="$KERL_BASE_DIR/builds"
-KERL_GIT_DIR="$KERL_BASE_DIR/gits"
+KERL_BASE_DIR="$HOME"/.kerl
+KERL_CONFIG="$HOME"/.kerlrc
+KERL_DOWNLOAD_DIR="${KERL_BASE_DIR:?}"/archives
+KERL_BUILD_DIR="${KERL_BASE_DIR:?}"/builds
+KERL_GIT_DIR="${KERL_BASE_DIR:?}"/gits
 if [ -n "$KERL_CONFIGURE_OPTIONS" ]; then
     _KCO="$KERL_CONFIGURE_OPTIONS"
 fi
@@ -56,10 +56,10 @@ KERL_SASL_STARTUP=
 KERL_INSTALL_MANPAGES=
 
 # ensure the base dir exsists
-mkdir -p "$KERL_BASE_DIR"
+mkdir -p "$KERL_BASE_DIR" || exit 1
 
 # source the config file if available
-if [ -f "$KERL_CONFIG" ]; then . "$KERL_CONFIG"; fi
+if [ -f "$KERL_CONFIG" ]; then source "$KERL_CONFIG"; fi
 
 if [ -n "$_KCO" ]; then
     KERL_CONFIGURE_OPTIONS="$_KCO"
@@ -89,7 +89,7 @@ else
     INSTALL_OPT=-sasl
 fi
 
-KERL_SYSTEM=`uname -s`
+KERL_SYSTEM=$(uname -s)
 case "$KERL_SYSTEM" in
     Darwin|FreeBSD|OpenBSD)
         MD5SUM="openssl md5"
@@ -107,7 +107,7 @@ usage()
 {
     echo "kerl: build and install Erlang/OTP"
     echo "usage: $0 <command> [options ...]"
-    echo "\n  <command>       Command to be executed\n"
+    printf "\n  <command>       Command to be executed\n\n"
     echo "Valid commands are:"
     echo "  build    Build specified release or git repository"
     echo "  install  Install the specified release at the given location"
@@ -135,21 +135,21 @@ get_releases()
 update_checksum_file()
 {
     echo "Getting the checksum file from erlang.org..."
-    curl -L $ERLANG_DOWNLOAD_URL/MD5 > "$KERL_DOWNLOAD_DIR/MD5" || exit 1
+    curl -L $ERLANG_DOWNLOAD_URL/MD5 > "$KERL_DOWNLOAD_DIR"/MD5 || exit 1
 }
 
 ensure_checksum_file()
 {
-    if [ ! -f "$KERL_DOWNLOAD_DIR/MD5" ]; then
+    if [ ! -f "$KERL_DOWNLOAD_DIR"/MD5 ]; then
         update_checksum_file
     fi
 }
 
 check_releases()
 {
-    if [ ! -f "$KERL_BASE_DIR/otp_releases" ]; then
+    if [ ! -f "$KERL_BASE_DIR"/otp_releases ]; then
         echo "Getting the available releases from erlang.org..."
-        get_releases > "$KERL_BASE_DIR/otp_releases"
+        get_releases > "$KERL_BASE_DIR"/otp_releases
     fi
 }
 
@@ -169,17 +169,17 @@ lion_support() {
 is_valid_release()
 {
     check_releases
-    for rel in `cat $KERL_BASE_DIR/otp_releases`; do
+    while read -r rel; do
         if [ "$1" = "$rel" ]; then
             return 0
         fi
-    done
+    done < "$KERL_BASE_DIR"/otp_releases
     return 1
 }
 
 assert_valid_release()
 {
-    if ! is_valid_release $1; then
+    if ! is_valid_release "$1"; then
         echo "$1 is not a valid Erlang/OTP release"
         exit 1
     fi
@@ -188,15 +188,15 @@ assert_valid_release()
 
 get_release_from_name()
 {
-    if [ -f "$KERL_BASE_DIR/otp_builds" ]; then
-        for l in `cat "$KERL_BASE_DIR/otp_builds"`; do
-            rel=`echo $l | cut -d "," -f 1`
-            name=`echo $l | cut -d "," -f 2`
+    if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
+        while read -r l; do
+            rel=$(echo "$l" | cut -d "," -f 1)
+            name=$(echo "$l" | cut -d "," -f 2)
             if [ "$name" = "$1" ]; then
                 echo "$rel"
                 return 0
             fi
-        done
+        done < "$KERL_BASE_DIR"/otp_builds
     fi
     return 1
 }
@@ -204,18 +204,18 @@ get_release_from_name()
 get_newest_valid_release()
 {
     check_releases
-    for rel in `cat $KERL_BASE_DIR/otp_releases | tail -1`; do
+    while read -r rel; do
         if [ ! -z "$rel" ]; then
             echo "$rel"
             return 0
         fi
-    done
+    done < "$KERL_BASE_DIR"/otp_releases | tail -1
     return 1
 }
 
 is_valid_installation()
 {
-    if [ -f "$1/activate" ]; then
+    if [ -f "$1"/activate ]; then
         return 0
     fi
     return 1
@@ -223,7 +223,7 @@ is_valid_installation()
 
 assert_valid_installation()
 {
-    if ! is_valid_installation $1; then
+    if ! is_valid_installation "$1"; then
         echo "$1 is not a kerl-managed Erlang/OTP installation"
         exit 1
     fi
@@ -232,24 +232,24 @@ assert_valid_installation()
 
 assert_build_name_unused()
 {
-    if [ -f "$KERL_BASE_DIR/otp_builds" ]; then
-        for l in `cat "$KERL_BASE_DIR/otp_builds"`; do
-            name=`echo $l | cut -d "," -f 2`
+    if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
+        while read -r l; do
+            name=$(echo "$l" | cut -d "," -f 2)
             if [ "$name" = "$1" ]; then
                 echo "There's already a build named $1"
                 exit 1
             fi
-        done
+        done < "$KERL_BASE_DIR"/otp_builds
     fi
 }
 
 do_git_build()
 {
-    assert_build_name_unused $3
+    assert_build_name_unused "$3"
 
-    GIT=`echo -n "$1" | $MD5SUM | cut -d " " -f $MD5SUM_FIELD`
+    GIT=$(echo -n "$1" | $MD5SUM | cut -d ' ' -f $MD5SUM_FIELD)
     mkdir -p "$KERL_GIT_DIR"
-    cd "$KERL_GIT_DIR"
+    cd "$KERL_GIT_DIR" || exit 1
     echo "Checking Erlang/OTP git repository from $1..."
     if [ ! -d "$GIT" ]; then
         git clone -q --mirror "$1" "$GIT" > /dev/null 2>&1
@@ -258,37 +258,37 @@ do_git_build()
             exit 1
         fi
     fi
-    cd "$GIT"
+    cd "$GIT" || exit 1
     git remote update --prune > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Error updating remote git repository"
         exit 1
     fi
 
-    rm -Rf "$KERL_BUILD_DIR/$3"
+    rm -Rf "${KERL_BUILD_DIR:?}/$3"
     mkdir -p "$KERL_BUILD_DIR/$3"
-    cd "$KERL_BUILD_DIR/$3"
+    cd "$KERL_BUILD_DIR/$3" || exit 1
     git clone -l "$KERL_GIT_DIR/$GIT" otp_src_git > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Error cloning local git repository"
         exit 1
     fi
-    cd otp_src_git
-    git checkout $2 > /dev/null 2>&1
+    cd otp_src_git || exit 1
+    git checkout "$2" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        git checkout -b $2 $2 > /dev/null 2>&1
+        git checkout -b "$2" "$2" > /dev/null 2>&1
     fi
     if [ $? -ne 0 ]; then
         echo "Couldn't checkout specified version"
-        rm -Rf "$KERL_BUILD_DIR/$3"
+        rm -Rf "${KERL_BUILD_DIR:?}/$3"
         exit 1
     fi
     if [ ! -x otp_build ]; then
         echo "Not a valid Erlang/OTP repository"
-        rm -Rf "$KERL_BUILD_DIR/$3"
+        rm -Rf "${KERL_BUILD_DIR:?}/$3"
         exit 1
     fi
-    LOGFILE="$KERL_BUILD_DIR/$3/otp_build.log"
+    LOGFILE="$KERL_BUILD_DIR/$3"/otp_build.log
     echo "Building Erlang/OTP $3 from git, please wait..."
     ./otp_build autoconf $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1 && \
         ./otp_build configure $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1
@@ -299,7 +299,7 @@ do_git_build()
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
         find ./lib -maxdepth 1 -type d -exec touch -f {}/SKIP \;
         for i in $KERL_CONFIGURE_APPLICATIONS; do
-            rm ./lib/$i/SKIP
+            rm ./lib/"$i"/SKIP
             if [ $? -ne 0 ]; then
                 echo "Couldn't prepare '$i' application for building"
                 exit 1
@@ -308,7 +308,7 @@ do_git_build()
     fi
     if [ -n "$KERL_CONFIGURE_DISABLE_APPLICATIONS" ]; then
         for i in $KERL_CONFIGURE_DISABLE_APPLICATIONS; do
-            touch -f ./lib/$i/SKIP
+            touch -f ./lib/"$i"/SKIP
             if [ $? -ne 0 ]; then
                 echo "Couldn't disable '$i' application for building"
                 exit 1
@@ -321,9 +321,9 @@ do_git_build()
         exit 1
     fi
     rm -f "$LOGFILE"
-    ./otp_build release -a "$KERL_BUILD_DIR/$3/release_git" > /dev/null 2>&1
-    cd "$KERL_BUILD_DIR/$3/release_git"
-    ./Install $INSTALL_OPT "$KERL_BUILD_DIR/$3/release_git" > /dev/null 2>&1
+    ./otp_build release -a "$KERL_BUILD_DIR/$3"/release_git > /dev/null 2>&1
+    cd "$KERL_BUILD_DIR/$3"/release_git || exit 1
+    ./Install $INSTALL_OPT "$KERL_BUILD_DIR/$3"/release_git > /dev/null 2>&1
     echo "Erlang/OTP $3 from git has been successfully built"
     list_add builds "git,$3"
 }
@@ -332,11 +332,11 @@ do_build()
 {
     case "$KERL_SYSTEM" in
         Darwin)
-            if [ `gcc --version 2>/dev/null | grep -i llvm | wc -l` = "1" ]; then
-                if lion_support $1; then
+            if [ "$(gcc --version 2>/dev/null | grep -i -c llvm)" = "1" ]; then
+                if lion_support "$1"; then
                     KERL_CONFIGURE_OPTIONS="CFLAGS=-O0 $KERL_CONFIGURE_OPTIONS"
                 else
-                    if [ -x "`which gcc-4.2`" ]; then
+                    if [ -x "$(which gcc-4.2)" ]; then
                         KERL_CONFIGURE_OPTIONS="CC=gcc-4.2 $KERL_CONFIGURE_OPTIONS"
                     else
                         KERL_CONFIGURE_OPTIONS="CC=llvm-gcc-4.2 CFLAGS=-O0 $KERL_CONFIGURE_OPTIONS"
@@ -348,8 +348,8 @@ do_build()
         ;;
     esac
 
-    assert_valid_release $1
-    assert_build_name_unused $2
+    assert_valid_release "$1"
+    assert_build_name_unused "$2"
 
     FILENAME=otp_src_$1.tar.gz
     download "$FILENAME"
@@ -359,12 +359,12 @@ do_build()
         UNTARDIRNAME="$KERL_BUILD_DIR/$2/otp_src_$1-kerluntar-$$"
         rm -rf "$UNTARDIRNAME"
         mkdir -p "$UNTARDIRNAME"
-        (cd "$UNTARDIRNAME" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME" && mv * "$KERL_BUILD_DIR/$2/otp_src_$1")
+        (cd "$UNTARDIRNAME" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME" && mv ./* "$KERL_BUILD_DIR/$2/otp_src_$1")
         rm -rf "$UNTARDIRNAME"
     fi
     echo "Building Erlang/OTP $1 ($2), please wait..."
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
-    cd "$ERL_TOP"
+    cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
     if [ -n "$KERL_USE_AUTOCONF" ]; then
         ./otp_build autoconf $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1 && \
@@ -381,7 +381,7 @@ do_build()
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
         find ./lib -maxdepth 1 -type d -exec touch -f {}/SKIP \;
         for i in $KERL_CONFIGURE_APPLICATIONS; do
-            rm ./lib/$i/SKIP
+            rm ./lib/"$i"/SKIP
             if [ $? -ne 0 ]; then
                 echo "Couldn't prepare '$i' application for building"
                 list_remove builds "$1 $2"
@@ -391,7 +391,7 @@ do_build()
     fi
     if [ -n "$KERL_CONFIGURE_DISABLE_APPLICATIONS" ]; then
         for i in $KERL_CONFIGURE_DISABLE_APPLICATIONS; do
-            touch -f ./lib/$i/SKIP
+            touch -f ./lib/"$i"/SKIP
             if [ $? -ne 0 ]; then
                 echo "Couldn't disable '$i' application for building"
                 exit 1
@@ -406,7 +406,7 @@ do_build()
     fi
     rm -f "$LOGFILE"
     ERL_TOP="$ERL_TOP" ./otp_build release -a "$KERL_BUILD_DIR/$2/release_$1" > /dev/null 2>&1
-    cd "$KERL_BUILD_DIR/$2/release_$1"
+    cd "$KERL_BUILD_DIR/$2/release_$1" || exit 1
     ./Install $INSTALL_OPT "$KERL_BUILD_DIR/$2/release_$1" > /dev/null 2>&1
     echo "Erlang/OTP $1 ($2) has been successfully built"
     list_add builds "$1,$2"
@@ -414,7 +414,7 @@ do_build()
 
 do_install()
 {
-    rel=`get_release_from_name $1`
+    rel=$(get_release_from_name "$1")
     if [ $? -ne 0 ]; then
         echo "No build named $1"
         exit 1
@@ -424,10 +424,10 @@ do_install()
         echo "Destination is not a directory"
         exit 1
     fi
-    absdir=`cd "$2" && pwd`
+    absdir=$(cd "$2" && pwd)
     echo "Installing Erlang/OTP $rel ($1) in $absdir..."
     ERL_TOP="$KERL_BUILD_DIR/$1/otp_src_$rel"
-    cd "$ERL_TOP"
+    cd "$ERL_TOP" || exit 1
     ERL_TOP="$ERL_TOP" ./otp_build release -a "$absdir" > /dev/null 2>&1 &&
         cd "$absdir" && ./Install $INSTALL_OPT "$absdir" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -435,7 +435,7 @@ do_install()
         exit 1
     fi
     list_add installations "$1 $absdir";
-    cat <<ACTIVATE > "$absdir/activate"
+    cat <<ACTIVATE > "$absdir"/activate
 # credits to virtualenv
 kerl_deactivate()
 {
@@ -512,7 +512,7 @@ ACTIVATE
                 tar -C "$absdir/html" -xzf "$KERL_DOWNLOAD_DIR/$FILENAME")
         fi
     else
-        rel=`get_newest_valid_release`
+        rel=$(get_newest_valid_release)
         if [ $? -ne 0 ]; then
             echo "No newest valid release"
             exit 1
@@ -548,18 +548,18 @@ do_deploy()
         echo "No host given"
         exit 1
     fi
-    host=$1
+    host="$1"
 
     assert_valid_installation "$2"
-    rel=`get_name_from_install_path "$2"`
-    path=$2
-    remotepath=$path
+    rel="$(get_name_from_install_path "$2")"
+    path="$2"
+    remotepath="$path"
 
     if [ ! -z "$3" ]; then
-        remotepath=$3
+        remotepath="$3"
     fi
 
-    ssh $KERL_DEPLOY_SSH_OPTIONS $host true > /dev/null 2>&1
+    ssh $KERL_DEPLOY_SSH_OPTIONS "$host" true > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Couldn't ssh to $host"
         exit 1
@@ -573,13 +573,13 @@ do_deploy()
         exit 1
     fi
 
-    ssh $KERL_DEPLOY_SSH_OPTIONS $host "cd \"$remotepath\" && env ERL_TOP=\`pwd\` ./Install $INSTALL_OPT \`pwd\` > /dev/null 2>&1"
+    ssh $KERL_DEPLOY_SSH_OPTIONS "$host" "cd \"$remotepath\" && env ERL_TOP=\"\`pwd\`\" ./Install $INSTALL_OPT \"\`pwd\`\" > /dev/null 2>&1"
     if [ $? -ne 0 ]; then
         echo "Couldn't install Erlang/OTP $rel to $host ($remotepath)"
         exit 1
     fi
 
-    ssh $KERL_DEPLOY_SSH_OPTIONS $host "cd \"$remotepath\" && sed -i -e \"s#$path#\`pwd\`#g\" activate"
+    ssh $KERL_DEPLOY_SSH_OPTIONS "$host" "cd \"$remotepath\" && sed -i -e \"s#$path#\"\`pwd\`\"#g\" activate"
     if [ $? -ne 0 ]; then
         echo "Couldn't completely install Erlang/OTP $rel to $host ($remotepath)"
         exit 1
@@ -593,8 +593,8 @@ do_deploy()
 
 list_print()
 {
-    if [ -f $KERL_BASE_DIR/otp_$1 ]; then
-        if [ "`cat "$KERL_BASE_DIR/otp_$1" | wc -l`" != "0" ]; then
+    if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
+        if [ "$(wc -l "$KERL_BASE_DIR/otp_$1")" != "0" ]; then
             if [ -z "$2" ]; then
                 cat "$KERL_BASE_DIR/otp_$1"
             else
@@ -609,11 +609,11 @@ list_print()
 list_add()
 {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
-        for l in `cat "$KERL_BASE_DIR/otp_$1"`; do
+        while read -r l; do
             if [ "$l" = "$2" ]; then
                 return 1
             fi
-        done
+        done < "$KERL_BASE_DIR/otp_$1"
         echo "$2" >> "$KERL_BASE_DIR/otp_$1"
     else
         echo "$2" > "$KERL_BASE_DIR/otp_$1"
@@ -630,7 +630,7 @@ list_remove()
 list_has()
 {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
-        grep $2 "$KERL_BASE_DIR/otp_$1" > /dev/null 2>&1 && return 0
+        grep "$2" "$KERL_BASE_DIR/otp_$1" > /dev/null 2>&1 && return 0
     fi
     return 1
 }
@@ -658,25 +658,25 @@ update_usage()
 get_active_path()
 {
     if [ -n "$_KERL_ACTIVE_DIR" ]; then
-        echo $_KERL_ACTIVE_DIR
+        echo "$_KERL_ACTIVE_DIR"
     fi
     return 0
 }
 
 get_name_from_install_path()
 {
-    if [ -f "$KERL_BASE_DIR/otp_installations" ]; then
-        grep -F "$1" "$KERL_BASE_DIR/otp_installations" | cut -d ' ' -f 1
+    if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
+        grep -F "$1" "$KERL_BASE_DIR"/otp_installations | cut -d ' ' -f 1
     fi
     return 0
 }
 
 do_active()
 {
-    ACTIVE_PATH=`get_active_path`
+    ACTIVE_PATH="$(get_active_path)"
     if [ -n "$ACTIVE_PATH" ]; then
         echo "The current active installation is:"
-        echo $ACTIVE_PATH
+        echo "$ACTIVE_PATH"
         return 0
     else
         echo "No Erlang/OTP kerl installation is currently active"
@@ -694,8 +694,8 @@ download()
     fi
     ensure_checksum_file
     echo "Verifying archive checksum..."
-    SUM=`$MD5SUM "$KERL_DOWNLOAD_DIR/$1" | cut -d " " -f $MD5SUM_FIELD`
-    ORIG_SUM=`grep -F "$1" "$KERL_DOWNLOAD_DIR/MD5" | cut -d " " -f 2`
+    SUM="$($MD5SUM "$KERL_DOWNLOAD_DIR/$1" | cut -d ' ' -f $MD5SUM_FIELD)"
+    ORIG_SUM="$(grep -F "$1" "$KERL_DOWNLOAD_DIR"/MD5 | cut -d ' ' -f 2)"
     if [ "$SUM" != "$ORIG_SUM" ]; then
         echo "Checksum error, check the files in $KERL_DOWNLOAD_DIR"
         exit 1
@@ -710,13 +710,13 @@ case "$1" in
                 echo "usage: $0 $1 $2 <git_url> <git_version> <build_name>"
                 exit 1
             fi
-            do_git_build $3 $4 $5
+            do_git_build "$3" "$4" "$5"
         else
             if [ $# -lt 3 ]; then
                 echo "usage: $0 $1 <release> <build_name>"
                 exit 1
             fi
-            do_build $2 $3
+            do_build "$2" "$3"
         fi
         ;;
     install)
@@ -729,7 +729,7 @@ case "$1" in
                 echo "Refusing to install in $HOME, this is a bad idea."
                 exit 1
             else
-                do_install $2 "$3"
+                do_install "$2" "$3"
             fi
         else
             if [ -z "$KERL_DEFAULT_INSTALL_DIR" ]; then
@@ -737,10 +737,10 @@ case "$1" in
                     echo "Refusing to install in $HOME, this is a bad idea."
                     exit 1
                 else
-                    do_install $2 .
+                    do_install "$2" .
                 fi
             else
-                do_install $2 "$KERL_DEFAULT_INSTALL_DIR/$2"
+                do_install "$2" "$KERL_DEFAULT_INSTALL_DIR/$2"
             fi
         fi
         ;;
@@ -750,12 +750,12 @@ case "$1" in
             exit 1
         fi
         if [ $# -eq 4 ]; then
-            do_deploy $2 "$3" "$4"
+            do_deploy "$2" "$3" "$4"
         else
             if [ $# -eq 3 ]; then
-                do_deploy $2 "$3"
+                do_deploy "$2" "$3"
             else
-                do_deploy $2 .
+                do_deploy "$2" '.'
             fi
         fi
         ;;
@@ -766,7 +766,7 @@ case "$1" in
         fi
         case "$2" in
             releases)
-                rm -f "$KERL_BASE_DIR/otp_releases"
+                rm -f "${KERL_BASE_DIR:?}"/otp_releases
                 check_releases
                 echo "The available releases are:"
                 list_print releases spaces
@@ -785,14 +785,14 @@ case "$1" in
         case "$2" in
             releases)
                 check_releases
-                list_print $2 space
-                echo "Run \"$0 update releases\" to update this list from erlang.org"
+                list_print "$2" space
+                echo "Run '$0 update releases' to update this list from erlang.org"
                 ;;
             builds)
-                list_print $2
+                list_print "$2"
                 ;;
             installations)
-                list_print $2
+                list_print "$2"
                 ;;
             *)
                 echo "Cannot list $2"
@@ -808,23 +808,23 @@ case "$1" in
         fi
         case "$2" in
             build)
-                rel=`get_release_from_name $3`
-                if [ -d "$KERL_BUILD_DIR/$3" ]; then
-                    rm -Rf "$KERL_BUILD_DIR/$3"
+                rel="$(get_release_from_name "$3")"
+                if [ -d "${KERL_BUILD_DIR:?}/$3" ]; then
+                    rm -Rf "${KERL_BUILD_DIR:?}/$3"
                 else
                     if [ -z "$rel" ]; then
                       echo "No build named $3"
                       exit 1
                     fi
                 fi
-                list_remove $2s "$rel,$3"
+                list_remove "$2"s "$rel,$3"
                 echo "The $3 build has been deleted"
                 ;;
             installation)
                 assert_valid_installation "$3"
                 rm -Rf "$3"
-                escaped=`echo "$3" | sed $SED_OPT -e 's#/$##' -e 's#\/#\\\/#g'`
-                list_remove $2s "$escaped"
+                escaped="$(echo "$3" | sed $SED_OPT -e 's#/$##' -e 's#\/#\\\/#g')"
+                list_remove "$2"s "$escaped"
                 echo "The installation in $3 has been deleted"
                 ;;
             *)
@@ -854,11 +854,11 @@ case "$1" in
         if [ -n "$2" ]; then
             FMT="$2"
         fi
-        ACTIVE_PATH=`get_active_path`
+        ACTIVE_PATH="$(get_active_path)"
         if [ -n "$ACTIVE_PATH" ]; then
-            ACTIVE_NAME=`get_name_from_install_path "$ACTIVE_PATH"`
+            ACTIVE_NAME="$(get_name_from_install_path "$ACTIVE_PATH")"
             if [ -z "$ACTIVE_NAME" ]; then
-                VALUE="`basename "$ACTIVE_PATH"`*"
+                VALUE="$(basename "$ACTIVE_PATH")*"
             else
                 VALUE="$ACTIVE_NAME"
             fi
@@ -874,14 +874,14 @@ case "$1" in
         case "$2" in
             all)
                 echo "Cleaning up compilation products for ALL builds"
-                rm -rf $KERL_BUILD_DIR/*
-                rm -rf $KERL_DOWNLOAD_DIR/*
-                rm -rf $KERL_GIT_DIR/*
+                rm -rf "${KERL_BUILD_DIR:?}"/*
+                rm -rf "${KERL_DOWNLOAD_DIR:?}"/*
+                rm -rf "${KERL_GIT_DIR:?}"/*
                 echo "Cleaned up all compilation products under $KERL_BUILD_DIR"
                 ;;
             *)
                 echo "Cleaning up compilation products for $3"
-                rm -rf $KERL_BUILD_DIR/$3
+                rm -rf "${KERL_BUILD_DIR:?}/$3"
                 echo "Cleaned up all compilation products under $KERL_BUILD_DIR"
                 ;;
         esac

--- a/kerl
+++ b/kerl
@@ -343,8 +343,18 @@ do_build()
 {
     case "$KERL_SYSTEM" in
         Darwin)
-            if [ "$(gcc --version 2>/dev/null | grep -i -c llvm)" = "1" ]; then
-                if lion_support "$1"; then
+            # Apple removed OpenSSL from El Capitan, but its still in this
+            # funky location, so set ssl headers to look here
+            RELVERSION=`uname -r`
+            case "$RELVERSION" in
+                15*)
+                    KERL_CONFIGURE_OPTIONS="--with-ssl=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr $KERL_CONFIGURE_OPTIONS"
+                ;;
+                *)
+                ;;
+            esac
+            if [ `gcc --version 2>/dev/null | grep -i llvm | wc -l` = "1" ]; then
+                if lion_support $1; then
                     KERL_CONFIGURE_OPTIONS="CFLAGS=-O0 $KERL_CONFIGURE_OPTIONS"
                 else
                     if [ -x "$(which gcc-4.2)" ]; then

--- a/kerl
+++ b/kerl
@@ -339,24 +339,38 @@ do_git_build()
     list_add builds "git,$3"
 }
 
+get_otp_version()
+{
+    echo $1 | sed $SED_OPT -e 's/R?([0-9]{1,2})[.AB]?[0-9]*/\1/'
+}
+
 do_build()
 {
     case "$KERL_SYSTEM" in
         Darwin)
             # Apple removed OpenSSL from El Capitan, but its still in this
             # funky location, so set ssl headers to look here
-            RELVERSION=`uname -r`
-            case "$RELVERSION" in
+            OSVERSION=`uname -r`
+            RELVERSION=`get_otp_version "$1"`
+            case "$OSVERSION" in
                 15*)
                     echo -n $KERL_CONFIGURE_OPTIONS | grep "ssl" 1>/dev/null 2>&1
                     # Reminder to self: 0 from grep means the string was detected
                     if [ $? -ne 0 ]; then
                         if [ ! -d /usr/include/openssl -o ! -d /usr/local/include/openssl ]; then
-                            if [ -d /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr ]; then
-                                KERL_CONFIGURE_OPTIONS="--with-ssl=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr $KERL_CONFIGURE_OPTIONS"
+                            xc_ssl='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr'
+                            if [ -d "$xc_ssl/include/openssl" ]
+                            then
+                                if [ $RELVERSION -ge 17 ]
+                                then
+                                    KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl --with-ssl-incl=$xc_ssl"
+                                else
+                                    KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$xc_ssl"
+                                fi
                             else
-                                echo "WARNING: No OpenSSL library was found in the usual places. Your Erlang will be built without crypto support!"
+                                echo 'WARNING: No OpenSSL library was found in the usual places. Your Erlang will be built without crypto support!'
                             fi
+                            unset xc_ssl
                         fi
                     fi
                 ;;

--- a/kerl
+++ b/kerl
@@ -21,6 +21,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+#Grep fix for mac pcre errors
+GREP_OPTIONS=''
+
 ERLANG_DOWNLOAD_URL=http://www.erlang.org/download
 
 KERL_BASE_DIR="$HOME"/.kerl


### PR DESCRIPTION
Apple officially removed OpenSSL libraries from El Capitan, so Erlang builds that rely on Xcode (which used to work) will now be built without functional crypto applications.  This patch auto-adds the header/library location so that Erlang releases will build with functional crypto on El Capitan.

There's probably a better way to do this but this seems to work ok.